### PR TITLE
Release 0.42

### DIFF
--- a/COPYRIGHT
+++ b/COPYRIGHT
@@ -1,7 +1,7 @@
 Auto Adjust Photo (aaphoto)
 Auto Adjust RGB (aaRGB)
 
-Copyright (C) 2006-2011 Andras Horvath
+Copyright (C) 2006-2013 Andras Horvath
 
 http://log69.com, mail@log69.com
 All rights reserved.

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,6 @@
 aaphoto Changelog:
 --------------------
+2012/02/20 - aaphoto v0.42 - tiny fix to set PNG compression manually and make it compatible with new version of libpng
 2011/01/26 - aaphoto v0.41 - new aaRGB v0.64 version update (see aaRGB changelog)
                            - add -- switch to mark the end of option list for posix compatibility
                            - fix some warnings given by -Wextra compile option

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,4 @@
+2012/02/20 - aaphoto v0.42 - tiny fix to set PNG compression manually and make it compatible with new version of libpng
 2011/01/26 - aaphoto v0.41 - new aaRGB v0.64 version update (see aaRGB changelog)
                            - add -- switch to mark the end of option list for posix compatibility
                            - fix some warnings given by -Wextra compile option


### PR DESCRIPTION
Small updates for consistency:
- COPYRIGHT date
- add latest information to Changelog and NEWS

Gentoo developers suggested [tagging and releasing](https://github.com/blog/1547-release-your-software) aaphoto-0.42 in GitHub and using the downloadable archive file for packaging instead of relying on snapshots based on commit IDs. So I took another round to see if there's anything to cleanup before a release.

What do you think about releasing 0.42? Feel free to let me know if I missed something or if there are any additional steps I can help with! :)
