### PR TITLE
Fix missing file

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -36,7 +36,7 @@ bin_PROGRAMS = aaphoto$(EXEEXT)
 subdir = .
 DIST_COMMON = README $(am__configure_deps) $(srcdir)/Makefile.am \
 	$(srcdir)/Makefile.in $(srcdir)/config.h.in \
-	$(top_srcdir)/configure AUTHORS COPYING ChangeLog INSTALL NEWS \
+	$(top_srcdir)/configure AUTHORS COPYING ChangeLog INSTALL \
 	TODO depcomp install-sh missing
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
 am__aclocal_m4_deps = $(top_srcdir)/configure.ac


### PR DESCRIPTION
NEWS has ben removed on 908db97a7e095a0ec3ddfefd09cb23e455c5cd1d, and
leads to the following error during compilation: `Makefile.am: required file `./NEWS' not found`